### PR TITLE
Add BSD utils support

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,8 +25,7 @@ First, thank you for consider contributing into this tool!
 * Use standard POSIX shell (No bash, zsh, fish magic allowed)
 * Always check your changes using `shellcheck`
 * When an user value is optional, it should be an option flag parsed by `getops`
-* When an user value is retrived through option flag, it should be overridable
-  with an environment variables
+* Each option flag should be overridable with an environment variables
 
 ### Markdown
 


### PR DESCRIPTION
I run `gh-candle` several times on a MacOS X environment with BSD utils on it to iron out the script. As per this comment all utils are GNU/BSD compatible, still, it should be nice to use GH Darwin runners for future integration tests.

PS: This address one of the tasks listed on #1 
